### PR TITLE
Add watch command to suppot live server mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -266,6 +266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -367,6 +376,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -738,6 +768,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +827,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +863,17 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -860,6 +941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
@@ -897,6 +979,36 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
 ]
 
 [[package]]
@@ -1003,7 +1115,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1801,6 +1913,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "colored",
+ "notify",
+ "notify-debouncer-mini",
  "once_cell",
  "pulldown-cmark",
  "reqwest",
@@ -2074,7 +2188,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2092,7 +2206,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2112,18 +2235,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2134,9 +2257,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2146,9 +2269,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2158,15 +2281,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2176,9 +2299,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2188,9 +2311,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2200,9 +2323,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2212,9 +2335,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ zip = "0.6"
 warp = "0.3"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1.0"
+notify = "6.1.1"
+notify-debouncer-mini = "0.4.1"
 
 
 [package.metadata]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -23,6 +23,7 @@ The commands are:
     init      Initialize to working directory
     serve     Serve starting the static http server
     build     Builder static html file and output to book
+    watch     Watch the file changes and rebuild the book
 
 Use typikon help <command> for more information about a command.
 ";

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,17 +1,18 @@
-use colored::Colorize;
-use core::fmt;
-use once_cell::sync::Lazy;
-use std::collections::HashMap;
-use std::path::Path;
-use std::sync::Mutex;
-use tokio::runtime::Runtime;
-
+use super::ouput_banner;
 use crate::{
     book::{self, settings},
     utils::{self, Logger},
 };
-
-use super::ouput_banner;
+use colored::Colorize;
+use core::fmt;
+use notify::RecursiveMode;
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::mpsc::channel;
+use std::sync::Mutex;
+use std::{path::Path, time::Duration};
+use tokio::runtime::Runtime;
 
 #[derive(Eq, Hash, PartialEq, Debug)]
 pub enum Command {
@@ -86,7 +87,7 @@ static HELP_INFO: Lazy<Mutex<HashMap<Command, colored::ColoredString>>> = Lazy::
     Mutex::new(help_info)
 });
 
-pub fn handle_build_command(_args: &[String]) {
+fn build_book() {
     let mut log = Logger::console_log();
     match book::new_builder() {
         Ok(mut builder) => match builder.generate_books() {
@@ -97,6 +98,10 @@ pub fn handle_build_command(_args: &[String]) {
         },
         Err(err) => log.error(format_args!("{}", err)),
     }
+}
+
+pub fn handle_build_command(_args: &[String]) {
+    build_book()
 }
 
 pub fn handle_serve_command(_args: &[String]) {
@@ -120,13 +125,76 @@ pub fn handle_serve_command(_args: &[String]) {
 
     let docs = warp::fs::dir(settings.directory.output.clone());
 
-    log.info(format_args!("Starting HTTP server on port {}", settings.port));
+    log.info(format_args!(
+        "Starting HTTP server on port {}",
+        settings.port
+    ));
 
     runtime.block_on(async {
         warp::serve(docs).run(([127, 0, 0, 1], settings.port)).await;
     });
 
     log.info(format_args!("HTTP server stopped."));
+}
+
+pub fn handle_live_serve_command() {
+    let mut log = Logger::console_log();
+    let settings = match settings::get_settings() {
+        Ok(settings) => settings,
+        Err(err) => {
+            log.error(format_args!("Failed to get settings: {:?}", err));
+            return;
+        }
+    };
+    // create a new builder
+    build_book();
+    let runtime = match Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            log.error(format_args!("Failed to create Tokio runtime: {:?}", err));
+            return;
+        }
+    };
+
+    let docs = warp::fs::dir(settings.directory.output.clone());
+
+    log.info(format_args!(
+        "Starting HTTP server on port {}",
+        settings.port
+    ));
+
+    runtime.spawn(async move {
+        warp::serve(docs).run(([127, 0, 0, 1], settings.port)).await;
+    });
+    // create a channel to receive file change events
+    let (tx, rx) = channel();
+
+    let mut debouncer = new_debouncer(Duration::from_secs(1), tx).unwrap();
+
+    debouncer
+        .watcher()
+        .watch(
+            Path::new(&settings.get_input_path()),
+            RecursiveMode::Recursive,
+        )
+        .unwrap();
+    runtime.block_on(async {
+        for res in rx {
+            match res {
+                Ok(events) => events.iter().for_each(|event| match event.kind {
+                    DebouncedEventKind::Any => {
+                        log.info(format_args!("File changed: {:?}", event.path));
+                        log.info(format_args!("Rebuilding book..."));
+                        build_book();
+                    }
+                    _ => {
+                        return;
+                    }
+                }),
+                Err(error) => log.error(format_args!("watch error: {:?}", error)),
+            }
+        }
+    });
 }
 
 pub fn handle_help_command(args: &[String]) {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -20,6 +20,7 @@ pub enum Command {
     Init,
     Help,
     Serve,
+    Watch,
     Unknown(String),
 }
 
@@ -30,6 +31,7 @@ impl Command {
             "init" => Command::Init,
             "help" => Command::Help,
             "serve" => Command::Serve,
+            "watch" => Command::Watch,
             _ => Command::Unknown(s.to_string()),
         }
     }
@@ -42,6 +44,7 @@ impl fmt::Display for Command {
             Command::Serve => write!(f, "serve"),
             Command::Init => write!(f, "init"),
             Command::Help => write!(f, "help"),
+            Command::Watch => write!(f, "watch"),
             Command::Unknown(s) => write!(f, "Unknown({})", s),
         }
     }
@@ -77,12 +80,22 @@ const SERVE_HELP_TEXT: &str = r"
 
 ";
 
+const WATCH_HELP_TEXT: &str = r"
+
+    Example:
+
+    Watch the file changes and rebuild the book 👇
+
+    $: mkdir example && typikon watch
+";
+
 static HELP_INFO: Lazy<Mutex<HashMap<Command, colored::ColoredString>>> = Lazy::new(|| {
     let mut help_info: HashMap<Command, colored::ColoredString> = HashMap::new();
 
     help_info.insert(Command::Build, BUILD_HELP_TEXT.green());
     help_info.insert(Command::Serve, SERVE_HELP_TEXT.green());
     help_info.insert(Command::Init, INIT_HELP_TEXT.green());
+    help_info.insert(Command::Watch, WATCH_HELP_TEXT.green());
 
     Mutex::new(help_info)
 });
@@ -137,7 +150,7 @@ pub fn handle_serve_command(_args: &[String]) {
     log.info(format_args!("HTTP server stopped."));
 }
 
-pub fn handle_live_serve_command() {
+pub fn handle_watch_command() {
     let mut log = Logger::console_log();
     let settings = match settings::get_settings() {
         Ok(settings) => settings,
@@ -209,13 +222,14 @@ pub fn handle_help_command(args: &[String]) {
     let help = HELP_INFO.lock().unwrap();
 
     match command {
-        Command::Build | Command::Init | Command::Help | Command::Serve => {
+        Command::Build | Command::Init | Command::Help | Command::Serve | Command::Watch => {
             if let Some(help_text) = help.get(&command) {
                 println!("{}", help_text);
             } else {
                 log.error(format_args!("No help available for command: {}", option));
             }
         }
+
         Command::Unknown(_) => {
             log.error(format_args!(
                 "Unknown option: {:?}. Available options: [init, serve, build]",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ fn main() {
         Command::Help => typikon::cli::handle_help_command(&args),
         Command::Build => typikon::cli::handle_build_command(&args),
         Command::Serve => typikon::cli::handle_serve_command(&args),
+        Command::Watch => typikon::cli::handle_watch_command(),
         Command::Unknown(_) => typikon::cli::output_banner_help(),
     }
 }

--- a/tests/book/live_server_test.rs
+++ b/tests/book/live_server_test.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use typikon::cli::commands::handle_live_serve_command;
+    use typikon::cli::commands::handle_watch_command;
 
     #[test]
     fn test_live_server() {
-        assert_eq!(handle_live_serve_command(), ());
+        assert_eq!(handle_watch_command(), ());
     }
 }

--- a/tests/book/live_server_test.rs
+++ b/tests/book/live_server_test.rs
@@ -1,0 +1,9 @@
+#[cfg(test)]
+mod tests {
+    use typikon::cli::commands::handle_live_serve_command;
+
+    #[test]
+    fn test_live_server() {
+        assert_eq!(handle_live_serve_command(), ());
+    }
+}

--- a/tests/book/mod.rs
+++ b/tests/book/mod.rs
@@ -1,3 +1,4 @@
-pub mod settings_test;
 pub mod builder_test;
+pub mod live_server_test;
 pub mod root_test;
+pub mod settings_test;


### PR DESCRIPTION
In the handle_watch_command function:
- Create a file watch channel and handle file change events.
- Trigger the rebuild process on file changes.